### PR TITLE
Fix entrypoint typo in tests

### DIFF
--- a/tests/integration/jobs/test_dsc_job.py
+++ b/tests/integration/jobs/test_dsc_job.py
@@ -582,13 +582,13 @@ class DSCJobCreationTestCase(DSCJobTestCaseWithCleanUp):
         SOURCE_PATH = os.path.join(
             os.path.dirname(__file__), "../fixtures/job_archive/"
         )
-        JOB_ENRTYPOINT = "job_archive/main.py"
+        JOB_ENTRYPOINT = "job_archive/main.py"
         job = (
             Job()
             .with_infrastructure(self.default_datascience_job.with_log_id(self.LOG_ID))
             .with_runtime(
                 ScriptRuntime()
-                .with_source(SOURCE_PATH, entrypoint=JOB_ENRTYPOINT)
+                .with_source(SOURCE_PATH, entrypoint=JOB_ENTRYPOINT)
                 .with_service_conda("mlcpuv1")
             )
             .create()
@@ -600,7 +600,7 @@ class DSCJobCreationTestCase(DSCJobTestCaseWithCleanUp):
                 "environment_variables": {
                     "CONDA_ENV_SLUG": "mlcpuv1",
                     "CONDA_ENV_TYPE": "service",
-                    "JOB_RUN_ENTRYPOINT": JOB_ENRTYPOINT,
+                    "JOB_RUN_ENTRYPOINT": JOB_ENTRYPOINT,
                 },
                 # "hyperparameter_values": None,
                 "job_type": "DEFAULT",

--- a/tests/unitary/default_setup/jobs/test_jobs_base.py
+++ b/tests/unitary/default_setup/jobs/test_jobs_base.py
@@ -298,20 +298,20 @@ class DataScienceJobRuntimeTest(DataScienceJobPayloadTest):
         self.assert_runtime_translation(runtime, expected_env_var=expected_env_var)
 
     def test_runtime_with_zip_entrypoint(self):
-        ZIP_JOB_ENRTYPOINT = "job_archive/main.py"
+        JOB_ENTRYPOINT = "job_archive/main.py"
         DIR_SOURCE_PATH = os.path.join(
             os.path.dirname(__file__), "../../../integration/fixtures/job_archive.zip"
         )
 
         expected_env_var = {
-            ScriptRuntimeHandler.CONST_ENTRYPOINT: ZIP_JOB_ENRTYPOINT,
+            ScriptRuntimeHandler.CONST_ENTRYPOINT: JOB_ENTRYPOINT,
             CondaRuntimeHandler.CONST_CONDA_TYPE: "service",
             CondaRuntimeHandler.CONST_CONDA_SLUG: "mlcpuv1",
         }
 
         runtime = (
             ScriptRuntime()
-            .with_source(DIR_SOURCE_PATH, entrypoint=ZIP_JOB_ENRTYPOINT)
+            .with_source(DIR_SOURCE_PATH, entrypoint=JOB_ENTRYPOINT)
             .with_service_conda("mlcpuv1")
         )
         self.assert_runtime_translation(runtime, expected_env_var)


### PR DESCRIPTION
## Summary
- fix entrypoint typo in integration job test
- fix entrypoint typo in default setup job test

## Testing
- `pre-commit run --files tests/unitary/default_setup/jobs/test_jobs_base.py tests/integration/jobs/test_dsc_job.py` *(command not found: pre-commit)*
- `pip install pre-commit` *(ProxyError: Cannot connect to proxy (403 Forbidden))*
- `pytest tests/unitary/default_setup/jobs/test_jobs_base.py -k test_runtime_with_zip_entrypoint` *(ConfigFileNotFound: Could not find config file at /root/.oci/config)*
- `pytest tests/integration/jobs/test_dsc_job.py -k test_create_job_with_directory` *(ModuleNotFoundError: No module named 'tests.integration.config')*


------
https://chatgpt.com/codex/tasks/task_e_68944e0cefc08322920e34938b4d688b